### PR TITLE
ci: Fix re-run action

### DIFF
--- a/.github/workflows/retry-workflow.yaml
+++ b/.github/workflows/retry-workflow.yaml
@@ -1,0 +1,19 @@
+name: Retry workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'The ID of the workflow run to rerun'
+        required: true
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -154,4 +154,4 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
-        run: gh run rerun ${{ github.run_id }} --failed
+        run: gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}


### PR DESCRIPTION
Run re-run in a different workflow to avoid `file may be broken` error