### PR TITLE
ci: add check for formatted go code

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,9 +16,11 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
-      - name: Setup GoReleaser
+      - name: fmt check
+        run: test -z $(go fmt ./...)
+      - name: lint
         run: make lint
 
   unit-tests:
@@ -30,7 +32,7 @@ jobs:
       - name: Ensure go version
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
       - name: run tests
         run: go test -json ./... > test.json
@@ -62,16 +64,16 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - {kubernetes: "1.28", concurrency: 1}
-          - {kubernetes: "1.29", concurrency: 1}
-          - {kubernetes: "1.28", concurrency: 2}
-          - {kubernetes: "1.29", concurrency: 2}
+          - { kubernetes: "1.28", concurrency: 1 }
+          - { kubernetes: "1.29", concurrency: 1 }
+          - { kubernetes: "1.28", concurrency: 2 }
+          - { kubernetes: "1.29", concurrency: 2 }
     steps:
       - uses: actions/checkout@v4
       - name: Ensure go version
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,13 @@ manifest:
 	sed -i 's|#\(.*\)--alertmanager-url=http://localhost:9093|\1--alertmanager-url=http://alertmanager.default:9093|g' \
 		install/kubernetes/deployment.yaml
 
+.PHONY: format
+format:
+	echo "Format source code"
+	go fmt ./...
+
 .PHONY: lint
-lint:
+lint: format
 	echo "Running linter on pkg"
 	go vet ./pkg/...
 	echo "Running linter on cmd"


### PR DESCRIPTION
Also added a Makefile target to do so.

Go has the build in feature to format the source files, we should enforce this here.